### PR TITLE
Update to pom-scijava parent, and switch to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+jdk: oraclejdk8
+branches:
+  only: master
+install: true
+script: ".travis/build.sh"
+after_success: ".travis/notify.sh Travis-Success"
+after_failure: ".travis/notify.sh Travis-Failure"
+env:
+  global:
+  - secure: hQAhNQ1yKBOpVbfq++ExxnXzuf4RJ5k/5p+XnaFPjRi69iGFgbNq9zQE/HoSskSU844x/dNykbuAU7Uq4ypUfTPusM4cqkJnoBztUQXxFxp8AUwO+s7xp48iQYej938MxdPufZIznJAW/KzXp9V6Yn2gdSyDJ5cZpwx1uAgGrSw=
+  - secure: VhIIXeHzaq1YshOdMlk/8M77lXn4N1RavSBi0crtxoukwNBLjyVMrkiWFHVr9T9XM09XcYpGLax5hlHXx63HoOVMKO19aUip8tduzS2GjAf8YrMvDy4L1rFry51lBQEGZaxgRqnS+7w1lEJTAdiHSuYHPxlm56XZug3WoZSL4hg=

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+dir="$(dirname "$0")"
+test "$TRAVIS_SECURE_ENV_VARS" = true \
+  -a "$TRAVIS_PULL_REQUEST" = false \
+  -a "$TRAVIS_BRANCH" = master &&
+  mvn -Pdeploy-to-imagej deploy --settings "$dir/settings.xml" ||
+  mvn install

--- a/.travis/notify.sh
+++ b/.travis/notify.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+curl -fs "https://jenkins.imagej.net/job/$1/buildWithParameters?token=$TOKEN_NAME&repo=$TRAVIS_REPO_SLUG&commit=$TRAVIS_COMMIT&pr=$TRAVIS_PULL_REQUEST"

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -1,0 +1,14 @@
+<settings>
+  <servers>
+    <server>
+      <id>imagej.releases</id>
+      <username>travis</username>
+      <password>${env.MAVEN_PASS}</password>
+    </server>
+    <server>
+      <id>imagej.snapshots</id>
+      <username>travis</username>
+      <password>${env.MAVEN_PASS}</password>
+    </server>
+  </servers>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>
-  			com.googlecode.efficient-java-matrix-library
-  		</groupId>
+			<groupId>com.googlecode.efficient-java-matrix-library</groupId>
 			<artifactId>ejml</artifactId>
 			<version>0.24</version>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,44 @@
 	<name>JavaITK thin plate spline</name>
 	<description>A java port of the ITK thin plate spline implementation.</description>
 
+	<developers>
+		<developer>
+			<id>bogovicj</id>
+			<name>John Bogovic</name>
+			<url>http://imagej.net/User:Bogovic</url>
+			<roles>
+				<role>founder</role>
+				<role>lead</role>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
+		<developer>
+			<id>axtimwalde</id>
+			<name>Stephan Saalfeld</name>
+			<url>http://imagej.net/User:Saalfeld</url>
+			<roles>
+				<role>founder</role>
+				<role>lead</role>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
+	</developers>
+	<contributors>
+		<contributor>
+			<name>Curtis Rueden</name>
+			<url>http://imagej.net/User:Rueden</url>
+			<properties><id>ctrueden</id></properties>
+		</contributor>
+	</contributors>
+
 	<scm>
 		<url>https://github.com/bogovicj/jitk-tps</url>
 		<connection>scm:git:git://github.com/bogovicj/jitk-tps</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,10 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>sc.fiji</groupId>
-		<artifactId>pom-fiji</artifactId>
-		<version>22.3.0</version>
+		<groupId>org.scijava</groupId>
+		<artifactId>pom-scijava</artifactId>
+		<version>14.0.0</version>
+		<relativePath />
 	</parent>
 
 	<groupId>jitk</groupId>
@@ -15,6 +16,19 @@
 
 	<name>JavaITK thin plate spline</name>
 	<description>A java port of the ITK thin plate spline implementation.</description>
+	<url>https://github.com/saalfeldlab/jitk-tps</url>
+	<inceptionYear>2014</inceptionYear>
+	<organization>
+		<name>Fiji</name>
+		<url>https://fiji.sc/</url>
+	</organization>
+	<licenses>
+		<license>
+			<name>Apache Software License, Version 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
 	<developers>
 		<developer>
@@ -54,16 +68,34 @@
 		</contributor>
 	</contributors>
 
+	<mailingLists>
+		<mailingList>
+			<name>ImageJ Forum</name>
+			<archive>http://forum.imagej.net/</archive>
+		</mailingList>
+	</mailingLists>
+
 	<scm>
-		<url>https://github.com/bogovicj/jitk-tps</url>
-		<connection>scm:git:git://github.com/bogovicj/jitk-tps</connection>
-		<developerConnection>scm:git:git@github.com:bogovicj/jitk-tps</developerConnection>
+		<url>https://github.com/saalfeldlab/jitk-tps</url>
+		<connection>scm:git:git://github.com/saalfeldlab/jitk-tps</connection>
+		<developerConnection>scm:git:git@github.com:saalfeldlab/jitk-tps</developerConnection>
 		<tag>HEAD</tag>
 	</scm>
 	<issueManagement>
 		<system>GitHub</system>
-		<url>https://github.com/bogovicj/jitk-tps/issues</url>
+		<url>https://github.com/saalfeldlab/jitk-tps/issues</url>
 	</issueManagement>
+	<ciManagement>
+		<system>Travis CI</system>
+		<url>https://travis-ci.org/saalfeldlab/jitk-tps</url>
+	</ciManagement>
+
+	<properties>
+		<package-name>jitk.spline</package-name>
+		<license.licenseName>apache_v2</license.licenseName>
+		<license.copyrightOwners>Howard Hughes Medical Institute.</license.copyrightOwners>
+		<license.projectName>JavaITK thin plate spline.</license.projectName>
+	</properties>
 
 	<repositories>
 		<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
 	</parent>
 
 	<repositories>
-		<!-- NB: for project parent -->
 		<repository>
 			<id>imagej.public</id>
 			<url>http://maven.imagej.net/content/groups/public</url>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>sc.fiji</groupId>
+		<artifactId>pom-fiji</artifactId>
+		<version>22.3.0</version>
+	</parent>
+
 	<groupId>jitk</groupId>
 	<artifactId>jitk-tps</artifactId>
 	<version>2.1.1-SNAPSHOT</version>
+
 	<name>JavaITK thin plate spline</name>
 	<description>A java port of the ITK thin plate spline implementation.</description>
+
+	<scm>
+		<url>https://github.com/bogovicj/jitk-tps</url>
+		<connection>scm:git:git://github.com/bogovicj/jitk-tps</connection>
+		<developerConnection>scm:git:git@github.com:bogovicj/jitk-tps</developerConnection>
+		<tag>HEAD</tag>
+	</scm>
+	<issueManagement>
+		<system>GitHub</system>
+		<url>https://github.com/bogovicj/jitk-tps/issues</url>
+	</issueManagement>
+
+	<repositories>
+		<repository>
+			<id>imagej.public</id>
+			<url>http://maven.imagej.net/content/groups/public</url>
+		</repository>
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>
@@ -33,26 +61,4 @@
 			<artifactId>opencsv</artifactId>
 		</dependency>
 	</dependencies>
-	<scm>
-		<url>https://github.com/bogovicj/jitk-tps</url>
-		<connection>scm:git:git://github.com/bogovicj/jitk-tps</connection>
-		<developerConnection>scm:git:git@github.com:bogovicj/jitk-tps</developerConnection>
-		<tag>HEAD</tag>
-	</scm>
-	<issueManagement>
-		<system>GitHub</system>
-		<url>https://github.com/bogovicj/jitk-tps/issues</url>
-	</issueManagement>
-	<parent>
-		<groupId>sc.fiji</groupId>
-		<artifactId>pom-fiji</artifactId>
-		<version>22.3.0</version>
-	</parent>
-
-	<repositories>
-		<repository>
-			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
-		</repository>
-	</repositories>
 </project>


### PR DESCRIPTION
This also adds `<developers>` and `<contributors>`.

Note that to fully switch to Travis, you will need to visit https://travis-ci.org/saalfeldlab/jitk-tps and enable the repository there.