### PR TITLE
Create fortan-kjppmp.gitignore:open

### DIFF
--- a/fortan-kjppmp.gitignore.
+++ b/fortan-kjppmp.gitignore.
@@ -1,0 +1,83 @@
+PROGRAM DSDQ
+
+C Minuit test case. Fortran-callable.
+
+C Fit randomly-generated leptonic K0 decays to the
+
+C time distribution expected for interfering K1 and K2,
+
+C with free parameters Re(X), Im(X), DeltaM, and GammaS.
+
+IMPLICIT DOUBLE PRECISION (A-H,O-Z)
+
+EXTERNAL FCNK0
+
+CC OPEN (UNIT=6,FILE=’DSDQ.OUT’,STATUS=’NEW’,FORM=’FORMATTED’)
+
+DIMENSION NPRM(5),VSTRT(5),STP(5),ARGLIS(10)
+
+CHARACTER*10 PNAM(5)
+
+DATA NPRM / 1 , 2 , 5 , 10 , 11 /
+
+DATA PNAM /’Re(X)’, ’Im(X)’, ’Delta M’,’T Kshort’,’T Klong’/
+
+DATA VSTRT/ 0. , 0. , .535 , .892 , 518.3 /
+
+DATA STP / 0.1 , 0.1 , 0.1 , 0. , 0. /
+
+C Initialize Minuit, define I/O unit numbers
+
+CALL MNINIT(5,6,7)
+
+C Define parameters, set initial values
+
+ZERO = 0.
+
+DO 11 I= 1, 5
+
+CALL MNPARM(NPRM(I),PNAM(I),VSTRT(I),STP(I),ZERO,ZERO,IERFLG)
+
+IF (IERFLG .NE. 0) THEN
+
+WRITE (6,’(A,I)’) ’ UNABLE TO DEFINE PARAMETER NO.’,I
+
+STOP
+
+ENDIF
+
+11 CONTINUE
+
+C
+
+CALL MNSETI(’Time Distribution of Leptonic K0 Decays’)
+
+C Request FCN to read in (or generate random) data (IFLAG=1)
+
+ARGLIS(1) = 1.
+
+CALL MNEXCM(FCNK0, ’CALL FCN’, ARGLIS ,1,IERFLG)
+
+C
+
+ARGLIS(1) = 5.
+
+CALL MNEXCM(FCNK0,’FIX’, ARGLIS ,1,IERFLG)
+
+ARGLIS(1) = 0.
+
+CALL MNEXCM(FCNK0,’SET PRINT’, ARGLIS ,1,IERFLG)
+
+CALL MNEXCM(FCNK0,’MIGRAD’, ARGLIS ,0,IERFLG)
+
+CALL MNEXCM(FCNK0,’MINOS’, ARGLIS ,0,IERFLG)
+
+CALL PRTERR
+
+ARGLIS(1) = 5.
+
+CALL MNEXCM(FCNK0,’RELEASE’, ARGLIS ,1,IERFLG)
+
+CALL MNEXCM(FCNK0,’MIGRAD’, ARGLIS ,0,IERFLG)
+
+CALL MNEXCM(FCNK0,’MINOS’, ARGLIS ,0,IERFLG)


### PR DESCRIPTION
PROGRAM DSDQ
C Minuit test case. Fortran-callable.
C Fit randomly-generated leptonic K0 decays to the
C time distribution expected for interfering K1 and K2,
C with free parameters Re(X), Im(X), DeltaM, and GammaS.
IMPLICIT DOUBLE PRECISION (A-H,O-Z)
EXTERNAL FCNK0
CC OPEN (UNIT=6,FILE=’DSDQ.OUT’,STATUS=’NEW’,FORM=’FORMATTED’)
DIMENSION NPRM(5),VSTRT(5),STP(5),ARGLIS(10)
CHARACTER*10 PNAM(5)
DATA NPRM / 1 , 2 , 5 , 10 , 11 /
DATA PNAM /’Re(X)’, ’Im(X)’, ’Delta M’,’T Kshort’,’T Klong’/
DATA VSTRT/ 0. , 0. , .535 , .892 , 518.3 /
DATA STP / 0.1 , 0.1 , 0.1 , 0. , 0. /
C Initialize Minuit, define I/O unit numbers
CALL MNINIT(5,6,7)
C Define parameters, set initial values
ZERO = 0.
DO 11 I= 1, 5
CALL MNPARM(NPRM(I),PNAM(I),VSTRT(I),STP(I),ZERO,ZERO,IERFLG)
IF (IERFLG .NE. 0) THEN
WRITE (6,’(A,I)’) ’ UNABLE TO DEFINE PARAMETER NO.’,I
STOP
ENDIF
11 CONTINUE
C
CALL MNSETI(’Time Distribution of Leptonic K0 Decays’)
C Request FCN to read in (or generate random) data (IFLAG=1)
ARGLIS(1) = 1.
CALL MNEXCM(FCNK0, ’CALL FCN’, ARGLIS ,1,IERFLG)
C
ARGLIS(1) = 5.
CALL MNEXCM(FCNK0,’FIX’, ARGLIS ,1,IERFLG)
ARGLIS(1) = 0.
CALL MNEXCM(FCNK0,’SET PRINT’, ARGLIS ,1,IERFLG)
CALL MNEXCM(FCNK0,’MIGRAD’, ARGLIS ,0,IERFLG)
CALL MNEXCM(FCNK0,’MINOS’, ARGLIS ,0,IERFLG)
CALL PRTERR
ARGLIS(1) = 5.
CALL MNEXCM(FCNK0,’RELEASE’, ARGLIS ,1,IERFLG)
CALL MNEXCM(FCNK0,’MIGRAD’, ARGLIS ,0,IERFLG)
CALL MNEXCM(FCNK0,’MINOS’, ARGLIS ,0,IERFLG).ftn